### PR TITLE
Support sublists

### DIFF
--- a/core/src/code/generator/html/generator.ts
+++ b/core/src/code/generator/html/generator.ts
@@ -72,15 +72,17 @@ export class Generator {
         const textNodeClassProps = this.getPropsFromNode(node, option);
         const attributes = htmlTag === "a" ? 'href="#" ' : "";
         const textProp = this.getText(node, option);
-        console.log("textProp");
-        console.log(textProp);
 
-        //@ts-ignore
-        // const listSegments = node.node.getListSegments();
-        // const listType = listSegments[0].listType;
-        // if (listSegments.length === 1 && listType !== "none") {
-        //   return `<${listType} ${attributes}${textNodeClassProps}>${textProp}</${listType}>`;
-        // }
+        // if textProp is enclosed in a <ul> or <ol> tag, we don't want to wrap another <div> around it
+        const result = /^<(ul|ol)>.*<\/(ul|ol)>$/s.exec(textProp);
+        if (result && result[1] === result[2]) {
+          const listTag = result[1];
+          const textPropWithoutListTag = textProp.substring(
+            4, // length of <ul> or <ol>
+            textProp.length - 5 // length of </ul> or </ol>
+          );
+          return `<${listTag} ${textNodeClassProps}>${textPropWithoutListTag}</${listTag}>`;
+        }
 
         return `<${htmlTag} ${attributes}${textNodeClassProps}>${textProp}</${htmlTag}>`;
       }
@@ -416,6 +418,8 @@ export class Generator {
                 htmlTagStack.push("li");
               }
 
+              if (option.cssFramework === "tailwindcss") {
+              }
               resultText += `<${listType}>`;
               htmlTagStack.push(listType);
             }

--- a/core/src/code/generator/html/generator.ts
+++ b/core/src/code/generator/html/generator.ts
@@ -419,8 +419,20 @@ export class Generator {
               }
 
               if (option.cssFramework === "tailwindcss") {
+                // Extra attributes needed due to Tailwind's CSS reset
+                const listProps = this.getPropsFromAttributes(
+                  {
+                    "margin-left": "40px",
+                    "list-style-type": listType === "ul" ? "disc" : "decimal",
+                  },
+                  option
+                );
+
+                resultText += `<${listType} ${listProps}>`;
+              } else {
+                resultText += `<${listType}>`;
               }
-              resultText += `<${listType}>`;
+
               htmlTagStack.push(listType);
             }
           } else if (indentationToAdd < 0) {

--- a/core/src/code/generator/tailwindcss/generator.ts
+++ b/core/src/code/generator/tailwindcss/generator.ts
@@ -107,18 +107,6 @@ const getPropsFromNode = (node: Node, option: Option): string => {
         ...node.getPositionalCssAttributes(),
       };
 
-      //@ts-ignore
-      // const listSegments = node.node.getListSegments();
-      // // Extra classes needed for lists due to Tailwind's CSS reset
-      // const listType = listSegments[0].listType;
-      // if (listSegments.length === 1 && listType === "ul") {
-      //   attributes["list-style-type"] = "disc";
-      // }
-
-      // if (listSegments.length === 1 && listType === "ol") {
-      //   attributes["list-style-type"] = "decimal";
-      // }
-
       return convertCssClassesToTwcssClasses(attributes, option, node.getId());
     }
     case NodeType.GROUP:

--- a/core/src/code/generator/tailwindcss/generator.ts
+++ b/core/src/code/generator/tailwindcss/generator.ts
@@ -108,16 +108,16 @@ const getPropsFromNode = (node: Node, option: Option): string => {
       };
 
       //@ts-ignore
-      const listSegments = node.node.getListSegments();
-      // Extra classes needed for lists due to Tailwind's CSS reset
-      const listType = listSegments[0].listType;
-      if (listSegments.length === 1 && listType === "ul") {
-        attributes["list-style-type"] = "disc";
-      }
+      // const listSegments = node.node.getListSegments();
+      // // Extra classes needed for lists due to Tailwind's CSS reset
+      // const listType = listSegments[0].listType;
+      // if (listSegments.length === 1 && listType === "ul") {
+      //   attributes["list-style-type"] = "disc";
+      // }
 
-      if (listSegments.length === 1 && listType === "ol") {
-        attributes["list-style-type"] = "decimal";
-      }
+      // if (listSegments.length === 1 && listType === "ol") {
+      //   attributes["list-style-type"] = "decimal";
+      // }
 
       return convertCssClassesToTwcssClasses(attributes, option, node.getId());
     }

--- a/core/src/design/adapter/figma/adapter.ts
+++ b/core/src/design/adapter/figma/adapter.ts
@@ -9,7 +9,7 @@ import {
   computePositionalRelationship,
 } from "../../../bricks/node";
 import { isEmpty } from "../../../utils";
-import { BoxCoordinates, Attributes, ExportFormat, ListSegment } from "../node";
+import { BoxCoordinates, Attributes, ExportFormat } from "../node";
 import {
   colorToString,
   colorToStringWithOpacity,
@@ -771,6 +771,8 @@ export class FigmaTextNodeAdapter extends FigmaNodeAdapter {
       "textCase",
       "fills",
       "letterSpacing",
+      "listOptions",
+      "indentation",
     ]);
 
     // for converting figma textDecoration to css textDecoration
@@ -789,6 +791,12 @@ export class FigmaTextNodeAdapter extends FigmaNodeAdapter {
       TITLE: "capitalize",
     } as const;
 
+    const figmaListOptionsToHtmlTagMap = {
+      NONE: "none",
+      UNORDERED: "ul",
+      ORDERED: "ol",
+    } as const;
+
     return styledTextSegments.map((segment) => ({
       ...segment,
       fontFamily: figmaFontNameToCssString(segment.fontName),
@@ -796,20 +804,6 @@ export class FigmaTextNodeAdapter extends FigmaNodeAdapter {
       textTransform: figmaTextCaseToCssTextTransformMap[segment.textCase],
       color: rgbaToString(getRgbaFromPaints(segment.fills)),
       letterSpacing: figmaLetterSpacingToCssString(segment.letterSpacing),
-    }));
-  }
-
-  getListSegments(): ListSegment[] {
-    const figmaListOptionsToHtmlTagMap = {
-      NONE: "none",
-      UNORDERED: "ul",
-      ORDERED: "ol",
-    } as const;
-
-    const listSegments = this.node.getStyledTextSegments(["listOptions"]);
-
-    return listSegments.map((segment) => ({
-      ...segment,
       listType: figmaListOptionsToHtmlTagMap[segment.listOptions.type],
     }));
   }

--- a/core/src/design/adapter/node.ts
+++ b/core/src/design/adapter/node.ts
@@ -45,13 +45,8 @@ export interface StyledTextSegment {
   textTransform: "none" | "uppercase" | "lowercase" | "capitalize";
   color: string;
   letterSpacing: string;
-}
-
-export interface ListSegment {
-  characters: string;
-  start: number;
-  end: number;
   listType: "none" | "ul" | "ol";
+  indentation: number;
 }
 
 export interface TextNode extends Node {
@@ -59,7 +54,6 @@ export interface TextNode extends Node {
   isItalic(): boolean;
   getFamilyName(): string;
   getStyledTextSegments(): StyledTextSegment[];
-  getListSegments(): ListSegment[];
 }
 
 export interface VectorNode extends Node {}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  - Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier --write .`).
-->

## Summary

Rewrote `getText()` to support nested lists.

Features:
- Will create nested `<ul>` or `<ol>` when you add indent a list in a Figma text node
- Will not wrap an extra `<div>` around the list if there is only one `<ul>` or `<ol>`. Instead will add props to the `<ul>` or `<ol>` tag instead.
- When Tailwind CSS is selected, we automatically adds `ml-10` and  `list-disc/decimal` to `<ul>` or `<ol>`. This is because of Tailwind's CSS reset.

## How did you test this change?
Tested the code works for a text node with varying text styles and indentation:
<img width="373" alt="Screen Shot 2023-05-11 at 10 43 18 AM" src="https://github.com/bricks-cloud/bricks/assets/19992630/7580cbab-f5cd-4791-8301-4b4ee001ab8a">

Generated code:
```jsx
import React from "react";
import "./style.css";

const GeneratedComponent = () => (
  <div className="text-xs w-[166px] text-blue-600 text-opacity-100 tracking-normal font-normal">
    Link to <span className="tracking-widest">an</span>
    <span className="underline tracking-widest">o</span>
    <span className="underline text-red-600 text-opacity-100 tracking-widest">
      t
    </span>
    <span className="text-red-600 text-opacity-100 tracking-widest">her</span>
    <span className="text-red-600 text-opacity-100"> pa</span>
    <span className="underline text-red-600 text-opacity-100">
      ge
      <br />
    </span>
    <ul className="ml-10 list-disc">
      <li>
        <span className="underline">as</span>df
        <ul className="ml-10 list-disc">
          <li>asdf</li>
        </ul>
      </li>
      <li>asdf</li>
    </ul>
  </div>
);

export default GeneratedComponent;
```