### PR TITLE
fix: preserve spaces in text

### DIFF
--- a/core/src/code/generator/html/generator.ts
+++ b/core/src/code/generator/html/generator.ts
@@ -703,7 +703,7 @@ const getAltProp = (node: Node): string => {
 };
 
 const escapeHtml = (str: string) => {
-  return str.replace(/["'{}]/g, function (match) {
+  return str.replace(/["'{} ]/g, function (match) {
     switch (match) {
       case '"':
         return "&quot;";
@@ -713,6 +713,8 @@ const escapeHtml = (str: string) => {
         return "&#123;";
       case "}":
         return "&#125;";
+      case " ":
+        return "&nbsp;";
     }
   });
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  - Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier --write .`).
-->

## Summary
when a TextNode includes some space, escapeHtml has bug which drop the spaces

## How did you test this change?

generte a TextNode with spaces in between charaters or words